### PR TITLE
Update SPIKEdistance.jl @inbounds macro

### DIFF
--- a/src/SPIKEdistance.jl
+++ b/src/SPIKEdistance.jl
@@ -38,7 +38,7 @@ function SPIKE_distance_profile(y1, y2;
     S⁻ = zeros(Float64, length(tvec))
     S⁺ = zeros(Float64, length(tvec))
     i1, i2 = 1, 1 # indices of the previous spike for each train
-    for k in 2:length(tvec)-1
+    @inbounds for k in 2:length(tvec)-1
         t = tvec[k]
         # First compute S given at the time of the next spike, but before
         # being exactly ON the spike


### PR DESCRIPTION

This minor change is accepted by existing inbuilt tests.

See for example:
```
julia> using Pkg
julia> Pkg.test("SpikeSynchrony")
     Testing SpikeSynchrony
      Status `/tmp/jl_XPbJZL/Project.toml`
  [3713708d] SpikeSynchrony v0.1.0
  [8dfed614] Test `@stdlib/Test`
      Status `/tmp/jl_XPbJZL/Manifest.toml`
  [3713708d] SpikeSynchrony v0.1.0
  [2a0f44e3] Base64 `@stdlib/Base64`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [9a3f8284] Random `@stdlib/Random`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [8dfed614] Test `@stdlib/Test`
     Testing Running tests...
Test Summary:  | Pass  Total
SPIKE distance |    9      9
┌ Warning: Assignment to `g` in soft scope is ambiguous because a global variable by the same name exists: `g` will be treated as a new local. Disambiguate by using `local g` to suppress this warning or `global g` to assign to the existing global variable.
└ @ ~/.julia/packages/SpikeSynchrony/8AiHX/test/vanRossum_tests.jl:24
Test Summary: | Pass  Total
vanRossum     |   40     40
     Testing SpikeSynchrony tests passed 
``` 
